### PR TITLE
Ignored Continue Last Run.feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ cypress/fixtures/cdisc_files
 cypress/fixtures/dictionaries
 cypress/fixtures/import_files
 
+cypress/features/Continue\ Last\ Run.feature
+
 /containers
 /docker
 /find


### PR DESCRIPTION
@aldefouw, would `redcap_cypress/cypress/features/Continue Last Run.feature` be an even better location than `redcap_rsvc/Feature Tests/Continue Last Run.feature`?  This would prevent us from having to update the `specPattern` since that path is already present.  Updating `specPattern` is a can of worms because it would likely lead to us having to move `cypress.config.js` into version control (and somehow handle people's local copies of it).