### PR TITLE
Target a specific REDCap version instead of the latest to clarify whe…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       image: ubuntu-2404:2024.11.1 # Machine image updates: https://circleci.com/developer/machine/image/ubuntu-2404
       resource_class: large
     environment:
-      REDCAP_VERSION: "99.99.99"
+      REDCAP_VERSION: "15.4.0"
 
 workflows:
   version: 2


### PR DESCRIPTION
@kcmcg, this targets a specific REDCap version instead of the latest to clarify whether test failures are caused by rctf changes or REDCap core changes.