### PR TITLE
Updated redcap to 15.4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       image: ubuntu-2404:2024.11.1 # Machine image updates: https://circleci.com/developer/machine/image/ubuntu-2404
       resource_class: large
     environment:
-      REDCAP_VERSION: "15.4.0"
+      REDCAP_VERSION: "15.4.2"
 
 workflows:
   version: 2


### PR DESCRIPTION
@kcmcg, I tested that last round of changes against 15.4.2, but forgot to create a PR to update redcap_cypress to that version afterward.  This is that PR.  The following confirms no failed tests since the last good run:
```
VUMC+mceverm:~/redcap_cypress_docker/redcap_cypress/redcap_rsvc
$ ./compare_cloud_results.sh 2271 2276|grep '^>'
>   'Feature Tests/A/e-Consent framework_24/A.3.24.3000. - eConsent PL edit.feature': 'PASSED',
>   'Feature Tests/C/Randomization_30/C.3.30.0500. - Randomization rights randomize.feature': 'PASSED',
VUMC+mceverm:~/redcap_cypress_docker/redcap_cypress/redcap_rsvc
$
```
![image](https://github.com/user-attachments/assets/ea5c9ef1-3d3e-4452-9e94-5f00a8697ca2)
