### PR TITLE
Tried parallelism of 30 again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
 jobs:
   run-tests:
     executor: shared-executor
-    parallelism: 28
+    parallelism: 30
     environment:
     steps:
       - checkout


### PR DESCRIPTION
@kcmcg, comparing these two build results confirms that increasing parallelism saves a couple of minutes now that the e-Consent tests are all running:

![image](https://github.com/user-attachments/assets/240d1d20-e199-420a-a6a2-6f82fd734863)
  