### PR TITLE
Update rsvc and rctf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "cypress": "^13.17.0",
         "del-cli": "^5.1.0",
         "move-cli": "^2.0.0",
-        "rctf": "git://github.com/vanderbilt-redcap/rctf#main",
-        "redcap_rsvc": "git://github.com/vanderbilt-redcap/redcap_rsvc#staging"
+        "rctf": "github:vanderbilt-redcap/rctf#main",
+        "redcap_rsvc": "github:vanderbilt-redcap/redcap_rsvc#staging"
       },
       "optionalDependencies": {
         "redcap_cypress_doc_theme": "git://github.com/vanderbilt-redcap/redcap_cypress_doc_theme#bf84bfa"
@@ -6602,8 +6602,7 @@
       }
     },
     "node_modules/rctf": {
-      "version": "1.0.117",
-      "resolved": "git+ssh://git@github.com/vanderbilt-redcap/rctf.git#cb4d123a39e9573aae4668884f6a0477b1817aab",
+      "resolved": "git+ssh://git@github.com/vanderbilt-redcap/rctf.git#969484ba9ab348caf762235ea2c17df0cf724386",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6787,8 +6786,7 @@
       "optional": true
     },
     "node_modules/redcap_rsvc": {
-      "version": "14.7.0",
-      "resolved": "git+ssh://git@github.com/vanderbilt-redcap/redcap_rsvc.git#543f087a9c1d4529384b27556f452045c23c4266",
+      "resolved": "git+ssh://git@github.com/vanderbilt-redcap/redcap_rsvc.git#25046f7363decafe85f877d9c73cb0c4b6071b0a",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6786,7 +6786,7 @@
       "optional": true
     },
     "node_modules/redcap_rsvc": {
-      "resolved": "git+ssh://git@github.com/vanderbilt-redcap/redcap_rsvc.git#25046f7363decafe85f877d9c73cb0c4b6071b0a",
+      "resolved": "git+ssh://git@github.com/vanderbilt-redcap/redcap_rsvc.git#8ed38d179d100689451683c30c0c516c58003634",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "redcap_cypress",
-  "version": "14.7.0",
   "description": "This repository is a template to assist you in writing **automated tests for REDCap**.",
   "devDependencies": {
     "cypress": "^13.17.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "cypress": "^13.17.0",
     "del-cli": "^5.1.0",
     "move-cli": "^2.0.0",
-    "rctf": "git://github.com/vanderbilt-redcap/rctf#main",
-    "redcap_rsvc": "git://github.com/vanderbilt-redcap/redcap_rsvc#staging"
+    "rctf": "github:vanderbilt-redcap/rctf#main",
+    "redcap_rsvc": "github:vanderbilt-redcap/redcap_rsvc#staging"
   },
   "optionalDependencies": {
     "redcap_cypress_doc_theme": "git://github.com/vanderbilt-redcap/redcap_cypress_doc_theme#bf84bfa"


### PR DESCRIPTION
@kcmcg, this updates the rsvc & rctf versions used in the master branch.  I think I might start updating these monthly along with the REDCap version.  Here are the build results.  The lone failing C.3.24 feature is fixed in an upcoming rsvc PR:

```
VUMC+mceverm:~/redcap_cypress_docker/redcap_cypress/redcap_rsvc
$ ./get_cloud_results.js 2284|grep FAIL
  'Feature Tests/C/e-Consent framework_24/C.3.24.2600. - PDF multi.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.0600. - Randomization DAG.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.0800. - Randomization automatic.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.0900. - Randomization lock.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1000. - Randomization assignment.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1200. - Randomization audit trail.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1300. - Randomization export.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1400. - Randomization model.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1700. - Randomization view allocation.feature': 'FAILED',
  'Feature Tests/C/Randomization_30/C.3.30.1800. - Randomization Admin actions.feature': 'FAILED',
VUMC+mceverm:~/redcap_cypress_docker/redcap_cypress/redcap_rsvc
$
```