### PR TITLE
Support automatic loading of step definitions from External Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "cypress-cucumber-preprocessor": {
-    "step_definitions": "cypress/support/step_definitions/"
+    "stepDefinitions": [
+      "cypress/support/step_definitions/*",
+      "../redcap_source/modules/**/automated-tests/step_definitions/*.js"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The aim of this change is to support the automatic loading of step definitions that are defined for an EM right within the `package.json` file by default.

We've standardized on the path for automated tests existing here: 

```
"../redcap_source/modules/**/automated-tests/
```

So, I think this makes sense.

# Pre-flight Checklist
- [X] Have all lines in this PR been reviewed & optimized by a human with appropriate coding skills? 
- [X] Are all the features in this PR tested by a human? 
- [X] Have other features this PR touches also been tested by a human?
- [X] Has the code been formatted for consistency and readability?
- [X] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
This change supports loading step definitions from the External Modules.  Without it, you'd have to manually copy step definitions into the base `redcap_cypress/support/step_definitions` folder.

# Context
This is the setup we're using at UW to make this work.

Note: 

1  **This is recommended approach per official documentation** within `cypress-cucumber-preprocessor` repository as linked here:  
https://github.com/badeball/cypress-cucumber-preprocessor/blob/master/docs/step-definitions.md

2 You'll notice that "step_definitions" (snakecase) moves to "stepDefinitions" (camelcase).  This is not a mistake.  It appears this is a long standing bug.  It should have been camelcase since the beginning. 